### PR TITLE
We need to add None as DXCC to the array separately

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -691,7 +691,9 @@ $('#dxcc_id').on('change', function() {
             return dxcc.adif == dxccadif;
         });
         $("#stationCQZoneInput").val(dxccinfo[0].cq);
-        // $("#stationITUZoneInput").val(dxccinfo[0].itu); // Commented out, since we do not have itu data.
+        if (dxccadif == 0) {
+            $("#stationITUZoneInput").val(dxccinfo[0].itu); // Only set ITU zone to none if DXCC none is selected. We don't have ITU data for other DXCCs.
+        }
     <?php } ?>
 });
 </script>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -1,5 +1,12 @@
 <script>
 var dxccarray = [];
+dxccarray.push({
+	adif: 0,
+	name: '- None -',
+	cq: '',
+	itu: '',
+});
+
 
 <?php
 if ($dxcc_list->result() > 0) {

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -1,5 +1,11 @@
 <script>
 var dxccarray = [];
+dxccarray.push({
+	adif: 0,
+	name: '- None -',
+	cq: '',
+	itu: '',
+});
 
 <?php
 if ($dxcc_list->result() > 0) {
@@ -16,6 +22,7 @@ if ($dxcc_list->result() > 0) {
 	}
 }
 ?>
+
 </script>
 
 <div class="container" id="create_station_profile">


### PR DESCRIPTION
Selecting DXCC None leads to a JS error because 0 as DXCC does not exist in the dxccarray. So we need to add that separately before filling in all the other DXCCs.