### PR TITLE
Auto-creation of contest sessions and assignment of QSOs imported through ADIF

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -448,6 +448,12 @@ class adif extends CI_Controller {
 			$data['qsocount'] = $custom_errors['qsocount'] ?? 0;
 			$data['skip_dupes'] = $this->input->post('skipDuplicate');
 			$data['imported_contests'] = $contest_qso_infos;
+			$data['qso_ids'] = $custom_errors['qsocount'] ?? 0 > 0 ? $custom_errors['qso_ids'] : [];
+
+			if(count($contest_qso_infos) > 0 and count($data['qso_ids']) > 0){
+				$this->load->model('contesting_model');
+				$affected_qsos = $this->contesting_model->assignorcreatecontestsessions($data['qso_ids']);
+			}
 
 			$data['page_title'] = __("ADIF Imported");
 			$this->load->view('interface_assets/header', $data);

--- a/application/models/Contest_admin_model.php
+++ b/application/models/Contest_admin_model.php
@@ -66,6 +66,26 @@ class Contest_admin_model extends CI_Model {
 		$this->db->insert('contest', $data);
 	}
 
+	function getActiveContestIDforADIFName($adif_name) {
+
+		//clean adif name
+		$clean_adif_name = $this->security->xss_clean($adif_name);
+
+		//prepare SQL
+		$sql = "SELECT id, name, adifname, active FROM contest WHERE adifname = ? AND active = 1 LIMIT 1";
+
+		//run query
+		$query = $this->db->query($sql, [$clean_adif_name]);
+
+		//check if exactly one row returns
+		if ($query->num_rows() !== 1) {
+			return null;
+		}
+
+		//return row
+		return $query->row();
+	}
+
 	function contest($id) {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -675,7 +675,7 @@ class Contesting_model extends CI_Model {
 				//if we still don't have a candidate, create contest session and load it immediately
 				if(!$assignment_candidate){
 					$this->create_contest_session($contest_id,$row->COL_TIME_ON, $row->COL_TIME_ON, $row->station_id, $notes, false);
-					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb($row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);	
+					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 				}
 			}
 
@@ -683,11 +683,11 @@ class Contesting_model extends CI_Model {
 			if($assignment_candidate){
 				
 				//modify start and end of contest session, for now only in cache
-				if($row->COL_TIME_ON < $assignment_candidate['time_start']){
+				if($row->COL_TIME_ON <= $assignment_candidate['time_start']){
 					$assignment_candidate['time_start'] = $row->COL_TIME_ON;
 				}
 
-				if($row->COL_TIME_ON > $assignment_candidate['time_end']){
+				if($row->COL_TIME_ON >= $assignment_candidate['time_end']){
 					$assignment_candidate['time_end'] = $row->COL_TIME_ON;
 				}
 
@@ -720,6 +720,16 @@ class Contesting_model extends CI_Model {
 			//save affected row count
 			$updated_rows = $this->db->affected_rows();
 
+			//update each contest session with the new start and end times from built cache
+			foreach ($contest_sessions as $session_id => $session) {
+				$this->db
+					->where('id', $session_id)
+					->update('contest_session', [
+						'time_start' => $session['time_start'],
+						'time_end' => $session['time_end'],
+					]);
+			}
+
 			//finally drop temporary table
 			$this->droptemporaryassignmenttable($tmp_table);
 
@@ -735,14 +745,13 @@ class Contesting_model extends CI_Model {
 
 		//try to find a candidate from cache
 		foreach ($contest_sessions as $session) {
-			if ($session['contest_adifname'] !== $contest_adifname) {
+			
+			//abort if static values are not matching
+			if ($session['contest_adifname'] !== $contest_adifname or $session['station_id'] !== $station_id) {
 				continue;
 			}
 
-			if ($session['station_id'] !== $station_id) {
-				continue;
-			}
-
+			//contest QSOs are usually within 48 hours of each other
 			$start_ts = strtotime($session['time_start']) - (48 * 60 * 60);
 			$end_ts   = strtotime($session['time_end']) + (48 * 60 * 60);
 
@@ -752,6 +761,7 @@ class Contesting_model extends CI_Model {
 			}
 		}
 
+		//return null if nothing is found
 		return null;
 	}
 
@@ -763,7 +773,8 @@ class Contesting_model extends CI_Model {
 		//prepare bindings
 		$binding = [];
 
-		//declare sql
+		//declare sql - contest QSOs are usually within 48 hours of each other
+		//if there are multiple candidates, prefer the one with the later end time
 		$sql = "SELECT cs.id AS contest_session_id,
 				cs.time_start AS time_start,
 				cs.time_end AS time_end,
@@ -779,17 +790,14 @@ class Contesting_model extends CI_Model {
 			JOIN contest c ON c.id = cs.contest_adif_id
 			JOIN station_profile sp ON sp.station_id = cs.station_id
 			WHERE cs.user_id = ? and c.adifname = ? and cs.station_id = ?
-			AND ? > DATE_SUB(cs.time_start, INTERVAL 48 HOUR)
-			AND ? < DATE_ADD(cs.time_end, INTERVAL 48 HOUR)
+			AND ? >= DATE_SUB(cs.time_start, INTERVAL 48 HOUR)
+			AND ? <= DATE_ADD(cs.time_end, INTERVAL 48 HOUR)
+			ORDER BY cs.time_end DESC
 			LIMIT 1";
 		
 		//create bindings
-		$binding[] = $user_id;
-		$binding[] = $contest_id;
-		$binding[] = $station_id;
-		$binding[] = $time;
-		$binding[] = $time;
-
+		$binding = [$user_id, $contest_id, $station_id, $time, $time];
+		
 		//execute sql
 		$query = $this->db->query($sql, $binding);
 		

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -638,12 +638,12 @@ class Contesting_model extends CI_Model {
 		foreach ($queryresult as $row) {
 			
 			//try to find assignment candidate from cache
-			$assignment_candidate = $this->getcontestsessionassignmentcandidatefromcache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+			$assignment_candidate = $this->getContestSessionAssignmentCandidateFromCache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 			
 			//if not found, try the database
 			if($assignment_candidate == null)
 			{
-				$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+				$assignment_candidate = $this->getContestSessionAssignmentCandidateFromDb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 			}
 
 			//if we found nothing, create a new one and load it asap
@@ -660,12 +660,12 @@ class Contesting_model extends CI_Model {
 
 					//recheck cache and db now that we know it is "other"
 					//try to find assignment candidate from cache
-					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromcache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+					$assignment_candidate = $this->getContestSessionAssignmentCandidateFromCache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 					
 					//if not found, try the database
 					if($assignment_candidate == null)
 					{
-						$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+						$assignment_candidate = $this->getContestSessionAssignmentCandidateFromDb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 					}
 				}else{
 					$contest_id = $contest_info->id;
@@ -675,7 +675,7 @@ class Contesting_model extends CI_Model {
 				//if we still don't have a candidate, create contest session and load it immediately
 				if(!$assignment_candidate){
 					$this->create_contest_session($contest_id,$row->COL_TIME_ON, $row->COL_TIME_ON, $row->station_id, $notes, false);
-					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+					$assignment_candidate = $this->getContestSessionAssignmentCandidateFromDb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 				}
 			}
 
@@ -738,7 +738,7 @@ class Contesting_model extends CI_Model {
 
 	}
 
-	function getcontestsessionassignmentcandidatefromcache(array $contest_sessions, $contest_adifname, $qso_datetime, $station_id) {
+	function getContestSessionAssignmentCandidateFromCache(array $contest_sessions, $contest_adifname, $qso_datetime, $station_id) {
 		
 		//get qso timestamp
 		$qso_ts = strtotime($qso_datetime);
@@ -765,7 +765,7 @@ class Contesting_model extends CI_Model {
 		return null;
 	}
 
-	function getcontestsessionassignmentcandidatefromdb($contest_id, $time, $station_id) {
+	function getContestSessionAssignmentCandidateFromDb($contest_id, $time, $station_id) {
 		
 		//get user id from session
 		$user_id = $this->session->userdata('user_id');

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -637,7 +637,7 @@ class Contesting_model extends CI_Model {
 		//iterate through each qso
 		foreach ($queryresult as $row) {
 			
-			//try to find assignment candidate from database
+			//try to find assignment candidate from cache
 			$assignment_candidate = $this->getcontestsessionassignmentcandidatefromcache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 			
 			//if not found, try the database
@@ -659,7 +659,7 @@ class Contesting_model extends CI_Model {
 					$contest_names_to_other[] = $row->COL_CONTEST_ID;
 
 					//recheck cache and db now that we know it is "other"
-					//try to find assignment candidate from database
+					//try to find assignment candidate from cache
 					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromcache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
 					
 					//if not found, try the database

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -567,4 +567,256 @@ class Contesting_model extends CI_Model {
 		}
 		
 	}
+
+	function assignorcreatecontestsessions($qso_ids) {
+		
+		//get relevant supporting data
+		$user_id = $this->session->userdata('user_id');
+		$maintable = $this->config->item('table_name');
+
+		//create table name for temporary table
+		$data = random_bytes(16);
+		$data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+    	$data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+		$tmp_table = 'tmp_qso_' . bin2hex($data);
+
+		//prepare QSO ids for temp table
+		$insert_data = [];
+
+		foreach ($qso_ids as $qso_id) {
+			$qso_id = (int) $qso_id;
+
+			if ($qso_id > 0) {
+				$insert_data[] = [
+					'qso_id' => $qso_id,
+					'contest_session_id' => null
+				];
+			}
+		}
+
+		//abort if empty
+		if (empty($insert_data)) {
+			return;
+		}
+
+		//create temporary table
+		$this->db->query("
+        CREATE TEMPORARY TABLE `" . $tmp_table . "` (
+            qso_id BIGINT(20) UNSIGNED NOT NULL,
+			contest_session_id INT(20) UNSIGNED,
+            PRIMARY KEY (qso_id)
+        ) ENGINE=InnoDB
+    	");
+
+		//insert to temporary table
+		$this->db->insert_batch($tmp_table, $insert_data);
+
+		//get all contest QSOs with necessary info
+		$query = $this->db
+			->select('tmp.qso_id, tmp.contest_session_id, main.COL_CONTEST_ID, main.COL_TIME_ON, main.station_id')
+			->from($tmp_table . ' AS tmp')
+			->join($maintable . ' AS main', 'tmp.qso_id = main.COL_PRIMARY_KEY', 'inner')
+			->where('main.COL_CONTEST_ID IS NOT NULL', null, false)
+			->where('main.COL_CONTEST_ID !=', '');
+
+		$queryresult = $this->db->get()->result();
+
+		//abort if empty
+		if(count($queryresult) < 1) {
+			$this->droptemporaryassignmenttable($tmp_table);
+			return;
+		}
+
+		//create cache
+		$contest_sessions = [];
+		$contest_names_to_other = [];
+
+		//load contest admin model
+		$this->load->is_loaded('contest_admin_model') ?: $this->load->model('contest_admin_model');
+
+		//iterate through each qso
+		foreach ($queryresult as $row) {
+			
+			//try to find assignment candidate from database
+			$assignment_candidate = $this->getcontestsessionassignmentcandidatefromcache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+			
+			//if not found, try the database
+			if($assignment_candidate == null)
+			{
+				$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+			}
+
+			//if we found nothing, create a new one and load it asap
+			if(!$assignment_candidate){
+				
+				//check with the contest admin model if this contest exists
+				$contest_info = $this->contest_admin_model->getActiveContestIDforADIFName($row->COL_CONTEST_ID);
+
+				//if it does not exist, use "Other" and put the provided Contest_ID in the notes
+				if($contest_info == null){
+					$contest_id = 1;
+					$notes = $row->COL_CONTEST_ID;
+					$contest_names_to_other[] = $row->COL_CONTEST_ID;
+
+					//recheck cache and db now that we know it is "other"
+					//try to find assignment candidate from database
+					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromcache($contest_sessions, in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+					
+					//if not found, try the database
+					if($assignment_candidate == null)
+					{
+						$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb(in_array($row->COL_CONTEST_ID, $contest_names_to_other) ? "Other" : $row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);
+					}
+				}else{
+					$contest_id = $contest_info->id;
+					$notes = "";
+				}
+
+				//if we still don't have a candidate, create contest session and load it immediately
+				if(!$assignment_candidate){
+					$this->create_contest_session($contest_id,$row->COL_TIME_ON, $row->COL_TIME_ON, $row->station_id, $notes, false);
+					$assignment_candidate = $this->getcontestsessionassignmentcandidatefromdb($row->COL_CONTEST_ID, $row->COL_TIME_ON, $row->station_id);	
+				}
+			}
+
+			//if we have a candidate, modify data and update temporary table
+			if($assignment_candidate){
+				
+				//modify start and end of contest session, for now only in cache
+				if($row->COL_TIME_ON < $assignment_candidate['time_start']){
+					$assignment_candidate['time_start'] = $row->COL_TIME_ON;
+				}
+
+				if($row->COL_TIME_ON > $assignment_candidate['time_end']){
+					$assignment_candidate['time_end'] = $row->COL_TIME_ON;
+				}
+
+				//save new state in cache
+				$contest_sessions[$assignment_candidate['contest_session_id']] = $assignment_candidate;
+
+				//update temporary table
+				$this->updatetemporaryassignmenttable($tmp_table, $row->qso_id, $assignment_candidate['contest_session_id']);
+
+			}
+			
+		}
+
+		//prepare SQL to transfer temporary table contents into final table
+			$sql = "
+				INSERT INTO contest_qsos (
+					contest_session_id,
+					qso_id
+				)
+				SELECT
+					contest_session_id,
+					qso_id
+				FROM {$tmp_table}
+				WHERE contest_session_id IS NOT NULL
+			";
+
+			//run query
+			$this->db->query($sql);
+
+			//save affected row count
+			$updated_rows = $this->db->affected_rows();
+
+			//finally drop temporary table
+			$this->droptemporaryassignmenttable($tmp_table);
+
+			//return updated rows
+			return $updated_rows;
+
+	}
+
+	function getcontestsessionassignmentcandidatefromcache(array $contest_sessions, $contest_adifname, $qso_datetime, $station_id) {
+		
+		//get qso timestamp
+		$qso_ts = strtotime($qso_datetime);
+
+		//try to find a candidate from cache
+		foreach ($contest_sessions as $session) {
+			if ($session['contest_adifname'] !== $contest_adifname) {
+				continue;
+			}
+
+			if ($session['station_id'] !== $station_id) {
+				continue;
+			}
+
+			$start_ts = strtotime($session['time_start']) - (48 * 60 * 60);
+			$end_ts   = strtotime($session['time_end']) + (48 * 60 * 60);
+
+			//check if qso is inside that space
+			if ($qso_ts > $start_ts && $qso_ts < $end_ts) {
+				return $session;
+			}
+		}
+
+		return null;
+	}
+
+	function getcontestsessionassignmentcandidatefromdb($contest_id, $time, $station_id) {
+		
+		//get user id from session
+		$user_id = $this->session->userdata('user_id');
+
+		//prepare bindings
+		$binding = [];
+
+		//declare sql
+		$sql = "SELECT cs.id AS contest_session_id,
+				cs.time_start AS time_start,
+				cs.time_end AS time_end,
+				cs.comment AS comment,
+				cs.settings AS settings,
+				c.name AS contest_name,
+				c.id AS contest_id,
+				c.adifname AS contest_adifname,
+				sp.station_id AS station_id,
+				sp.station_callsign AS station_callsign,
+				sp.station_gridsquare AS station_gridsquare
+			FROM contest_session cs
+			JOIN contest c ON c.id = cs.contest_adif_id
+			JOIN station_profile sp ON sp.station_id = cs.station_id
+			WHERE cs.user_id = ? and c.adifname = ? and cs.station_id = ?
+			AND ? > DATE_SUB(cs.time_start, INTERVAL 48 HOUR)
+			AND ? < DATE_ADD(cs.time_end, INTERVAL 48 HOUR)
+			LIMIT 1";
+		
+		//create bindings
+		$binding[] = $user_id;
+		$binding[] = $contest_id;
+		$binding[] = $station_id;
+		$binding[] = $time;
+		$binding[] = $time;
+
+		//execute sql
+		$query = $this->db->query($sql, $binding);
+		
+		//return as array
+		return $query->row_array();
+	}
+
+	function droptemporaryassignmenttable($tablename) {
+		$this->db->query("DROP TEMPORARY TABLE IF EXISTS " . $tablename . ";");
+	}
+
+	function updatetemporaryassignmenttable($tmp_table, $qso_id, $contest_session_id)
+	{
+		
+		//sanity checks
+		if ($qso_id <= 0 || $contest_session_id <= 0) {
+			return false;
+		}
+
+		//update temporary table
+		$this->db
+			->where('qso_id', $qso_id)
+			->update($tmp_table, [
+				'contest_session_id' => $contest_session_id
+			]);
+
+		//return affected rows
+		return ($this->db->affected_rows() >= 0);
+	}
 }

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -623,7 +623,7 @@ class Contesting_model extends CI_Model {
 
 		//abort if empty
 		if(count($queryresult) < 1) {
-			$this->droptemporaryassignmenttable($tmp_table);
+			$this->dropTemporaryAssignmentTable($tmp_table);
 			return;
 		}
 
@@ -695,7 +695,7 @@ class Contesting_model extends CI_Model {
 				$contest_sessions[$assignment_candidate['contest_session_id']] = $assignment_candidate;
 
 				//update temporary table
-				$this->updatetemporaryassignmenttable($tmp_table, $row->qso_id, $assignment_candidate['contest_session_id']);
+				$this->updateTemporaryAssignmentTable($tmp_table, $row->qso_id, $assignment_candidate['contest_session_id']);
 
 			}
 			
@@ -731,7 +731,7 @@ class Contesting_model extends CI_Model {
 			}
 
 			//finally drop temporary table
-			$this->droptemporaryassignmenttable($tmp_table);
+			$this->dropTemporaryAssignmentTable($tmp_table);
 
 			//return updated rows
 			return $updated_rows;
@@ -805,11 +805,11 @@ class Contesting_model extends CI_Model {
 		return $query->row_array();
 	}
 
-	function droptemporaryassignmenttable($tablename) {
+	function dropTemporaryAssignmentTable($tablename) {
 		$this->db->query("DROP TEMPORARY TABLE IF EXISTS " . $tablename . ";");
 	}
 
-	function updatetemporaryassignmenttable($tmp_table, $qso_id, $contest_session_id)
+	function updateTemporaryAssignmentTable($tmp_table, $qso_id, $contest_session_id)
 	{
 		
 		//sanity checks

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4886,7 +4886,17 @@ class Logbook_model extends CI_Model {
 		gc_collect_cycles();
 		$custom_errors['qsocount'] = count($a_qsos);
 		if ($custom_errors['qsocount'] > 0) {
-			$this->db->insert_batch($this->config->item('table_name'), $a_qsos);
+			
+			$this->db->trans_start();
+
+			foreach ($a_qsos as $qso) {
+				$this->db->insert($this->config->item('table_name'), $qso);
+				$ids[] = $this->db->insert_id();
+			}
+
+			$this->db->trans_complete();
+
+			$custom_errors['qso_ids'] = $ids;
 		}
 		foreach ($amsat_qsos as $amsat_qso) {
 			$this->upload_amsat_status($data);


### PR DESCRIPTION
Continuation of [this PR](https://github.com/DB4SCW/wavelog/pull/5) about automatically creating valid and fitting contest sessions for ADIF imports.

At the moment only implemented for ADIF Import from UI.